### PR TITLE
Clarify why _.method is not available

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ We can easily create math expressions:
 
 Work in progress:
 
-- `_.method()` is not supported yet for the same reason
+- `_.method()` is not supported yet, because we need a complex `mypy` plugin for this
 - `TypedDict`s are not tested with `__getitem__`
 - `__getitem__` does not work with list and tuples (collections), only dicts (mappings)
 


### PR DESCRIPTION
The first line of the "Work in progress" did not make sense as the line originally above it 
```
`_.some_attribute` is not supported yet, because we need a complex `mypy` plugin for this.
```
had been deleted